### PR TITLE
Implement client-side caching and reorganize cache architecture

### DIFF
--- a/app/lib/auth/auth.server.ts
+++ b/app/lib/auth/auth.server.ts
@@ -56,7 +56,7 @@ export async function getUser(request: Request) {
 }
 
 export async function getUserId(request: Request) {
-  let { user, cookie } = await getUser(request);
+  let { user } = await getUser(request);
   if (user == null) {
     return null;
   }

--- a/app/lib/cache/cache.client.ts
+++ b/app/lib/cache/cache.client.ts
@@ -1,0 +1,44 @@
+import localforage from "localforage";
+import { GameLibrary } from "../game-library";
+
+export interface CachedData<T> {
+  data: T;
+  timestamp: number;
+  version: string;
+}
+
+export type CachedGameLibrary = CachedData<GameLibrary>;
+
+export let gameLibraryStore = localforage.createInstance({
+  name: "gameLibrary",
+  driver: localforage.LOCALSTORAGE,
+  storeName: "cache",
+  description: "Cached game library data",
+});
+
+export async function getGameLibraryCache(
+  key: string
+): Promise<CachedGameLibrary | null> {
+  try {
+    return await gameLibraryStore.getItem(key);
+  } catch (error) {
+    console.error("Failed to get from cache:", error);
+    return null;
+  }
+}
+
+export async function setGameLibraryCache(
+  key: string,
+  data: any,
+  version: string
+): Promise<void> {
+  try {
+    await gameLibraryStore.setItem(key, {
+      data,
+      timestamp: Date.now(),
+      version,
+    });
+  } catch (error) {
+    console.error("Failed to set cache:", error);
+  }
+}

--- a/app/lib/cache/cache.server.ts
+++ b/app/lib/cache/cache.server.ts
@@ -43,21 +43,6 @@ export let cache: Cache = {
   },
 };
 
-export function generateCacheKey(userId: number, ...routeParts: string[]) {
-  return `${userId}:${routeParts.join("/")}`;
-}
-
-export function bustCache(userId: number | null, ...routeParts: string[]) {
-  let routePattern = routeParts.join("/");
-
-  if (userId) {
-    let key = generateCacheKey(userId, ...routeParts);
-    cache.delete(key);
-  } else {
-    // If no userId provided, bust cache for all users matching the route pattern
-    let keysToDelete = Array.from(lruCache.keys()).filter((key) =>
-      key.includes(`:${routePattern}`)
-    );
-    keysToDelete.forEach((key) => cache.delete(key));
-  }
+export function bustCache(cacheKey: string) {
+  cache.delete(cacheKey);
 }

--- a/app/lib/const.ts
+++ b/app/lib/const.ts
@@ -27,3 +27,5 @@ export const CATEGORY_PORT = 11;
 
 export const CACHE_TTL = 3_600_000; // ms in 1hr
 export const CACHE_SWR = 45_000;
+
+export const EXPLORE_CACHE_KEY = "/explore";

--- a/app/lib/game-library.ts
+++ b/app/lib/game-library.ts
@@ -1,0 +1,194 @@
+// app/routes/emulator.tsx
+import { bufferToStringIfExists } from "@/lib/fs.server";
+import { prisma } from "@/lib/prisma.server";
+import { User } from "@prisma/client";
+import { getRandomGame, getTopGenres } from "@prisma/client/sql";
+
+export type GameLibrary = ReturnType<typeof getGameLibrary>;
+export type GameDetails = ReturnType<typeof getGameDetailsData>;
+
+function getDiscoveryQueue(games: any[], topGenres: any[]) {
+  let topGenreIds = topGenres.map((genre) => genre.id);
+  let filteredGames = games.filter((game) =>
+    game.gameGenres.some((gg: any) => topGenreIds.includes(gg.genreId))
+  );
+  let shuffled = filteredGames.sort(() => 0.5 - Math.random());
+  return shuffled.slice(0, 3);
+}
+
+async function getLastPlayedGame(
+  userId: number,
+  filterIncompleteGame: boolean
+) {
+  let andFilter = [
+    ...(filterIncompleteGame
+      ? [
+          {
+            game: {
+              backgroundImage: {
+                not: null,
+              },
+            },
+          },
+        ]
+      : []),
+  ];
+  return await prisma.gameStats.findFirst({
+    select: {
+      game: {
+        select: {
+          id: true,
+          title: true,
+          summary: true,
+          backgroundImage: true,
+          system: {
+            select: {
+              title: true,
+            },
+          },
+        },
+      },
+    },
+    where: {
+      AND: [
+        {
+          userId,
+        },
+        ...andFilter,
+      ],
+    },
+    orderBy: {
+      lastPlayedAt: "desc",
+    },
+  });
+}
+
+export async function getGameLibrary(user: User) {
+  let settings = await prisma.settings.findFirstOrThrow();
+
+  let [games, [randomGame], genres, lastPlayedGame] = await Promise.all([
+    prisma.game.findMany({
+      select: {
+        id: true,
+        title: true,
+        coverArt: true,
+        rating: true,
+        summary: true,
+        system: {
+          select: {
+            title: true,
+          },
+        },
+        gameGenres: {
+          select: {
+            genreId: true,
+          },
+        },
+      },
+    }),
+    prisma.$queryRawTyped(getRandomGame(settings.spotlightIncompleteGame)),
+    prisma.$queryRawTyped(getTopGenres()),
+    getLastPlayedGame(user.id, settings.spotlightIncompleteGame),
+  ]);
+  let topFiveGenres = genres.slice(0, 5);
+  let discoveryQueue = getDiscoveryQueue(games, topFiveGenres);
+
+  // Parallelize data transformations
+  let [
+    processedGames,
+    processedDiscoveryQueue,
+    processedGenres,
+    processedRandomGame,
+    processedLastPlayedGame,
+  ] = await Promise.all([
+    Promise.all(
+      games.map((game) => ({
+        ...game,
+        coverArt: bufferToStringIfExists(game.coverArt),
+      }))
+    ),
+    Promise.all(
+      discoveryQueue.map((d) => ({
+        ...d,
+        coverArt: bufferToStringIfExists(d.coverArt),
+      }))
+    ),
+    Promise.all(
+      genres.map((genre) => ({
+        ...genre,
+        count: Number(genre.count),
+        coverArt: bufferToStringIfExists(genre.coverArt),
+      }))
+    ),
+    {
+      ...randomGame,
+      backgroundImage: bufferToStringIfExists(randomGame.backgroundImage),
+    },
+    lastPlayedGame
+      ? {
+          id: lastPlayedGame.game.id,
+          title: lastPlayedGame.game.title,
+          summary: lastPlayedGame.game.summary,
+          system: lastPlayedGame.game.system.title,
+          backgroundImage: bufferToStringIfExists(
+            lastPlayedGame.game.backgroundImage
+          ),
+        }
+      : undefined,
+  ]);
+
+  return {
+    games: processedGames,
+    lastPlayedGame: processedLastPlayedGame,
+    randomGame: processedRandomGame,
+    settings,
+    discoveryQueue: processedDiscoveryQueue,
+    genres: processedGenres,
+  };
+}
+
+export async function getGameDetailsData(id: number, user: User) {
+  let game = await prisma.game.findFirst({
+    where: {
+      id,
+    },
+    select: {
+      id: true,
+      title: true,
+      releaseDate: true,
+      backgroundImage: true,
+      summary: true,
+      coverArt: true,
+      borrowedBy: {
+        select: {
+          id: true,
+          roleId: true,
+        },
+      },
+      system: {
+        select: {
+          id: true,
+          title: true,
+        },
+      },
+      gameGenres: {
+        select: {
+          genre: {
+            select: {
+              name: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!game) throw new Error("Where the game at dog?");
+
+  return {
+    ...game,
+    coverArt: bufferToStringIfExists(game.coverArt),
+    backgroundImage: bufferToStringIfExists(game.backgroundImage),
+    user,
+  };
+}

--- a/app/routes/genre.$id.tsx
+++ b/app/routes/genre.$id.tsx
@@ -5,11 +5,10 @@ import { Card, CardContent } from "@/components/ui/card";
 import { requireUser } from "@/lib/auth/auth.server";
 import {
   cache,
-  generateCacheKey,
   generateETag,
   getGlobalVersion,
   updateGlobalVersion,
-} from "@/lib/cache.server";
+} from "@/lib/cache/cache.server";
 import { bufferToStringIfExists } from "@/lib/fs.server";
 import { prisma } from "@/lib/prisma.server";
 import { cn } from "@/lib/utils";
@@ -105,7 +104,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     if (!genreId) throw new Error("genreId could not be pulled from URL");
 
     let genreInfo = await cachified({
-      key: generateCacheKey(user.id, "genre", genreId),
+      key: `genre-${genreId}`,
       cache,
       async getFreshValue() {
         return await fetchGenreInfo(genreId, user.id);

--- a/app/routes/play.$system.$id.tsx
+++ b/app/routes/play.$system.$id.tsx
@@ -2,7 +2,7 @@ import { useInitializeEmulator } from "@/hooks/use-initialize-emulator";
 import { useNavigationCleanup } from "@/hooks/use-navigation-cleanup";
 import { useLoadSaveFiles } from "@/hooks/use-save-files";
 import { requireUser } from "@/lib/auth/auth.server";
-import { updateGlobalVersion } from "@/lib/cache.server";
+import { updateGlobalVersion } from "@/lib/cache/cache.server";
 import { DATA_DIR } from "@/lib/const";
 import { prisma } from "@/lib/prisma.server";
 import { Submission } from "@conform-to/react";

--- a/app/routes/resources+/warm-cache.ts
+++ b/app/routes/resources+/warm-cache.ts
@@ -1,0 +1,43 @@
+import { UserRoles } from "@/lib/auth/providers.server";
+import {
+  cache,
+  generateETag,
+  getGlobalVersion,
+  updateGlobalVersion,
+} from "@/lib/cache/cache.server";
+import { CACHE_SWR, CACHE_TTL, EXPLORE_CACHE_KEY } from "@/lib/const";
+import { getGameLibrary } from "@/lib/game-library";
+import { prisma } from "@/lib/prisma.server";
+import cachified from "@epic-web/cachified";
+import { json } from "@remix-run/node";
+
+export async function loader() {
+  try {
+    let data = await cachified({
+      key: EXPLORE_CACHE_KEY,
+      cache,
+      async getFreshValue() {
+        let user = await prisma.user.findFirstOrThrow({
+          where: {
+            roleId: UserRoles.ADMIN,
+          },
+        });
+        return await getGameLibrary(user);
+      },
+      ttl: CACHE_TTL,
+      swr: CACHE_SWR,
+    });
+    return json(data, {
+      headers: {
+        "Cache-Control": "max-age=900, stale-while-revalidate=3600",
+        ETag: `"${generateETag(data)}"`,
+        "X-Version": getGlobalVersion().toString(),
+      },
+    });
+  } catch (error) {
+    updateGlobalVersion();
+    return json({
+      error: `${error}`,
+    });
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,12 @@ services:
     volumes:
       - ./prisma:/app/prisma
       - sqlite-data:/app/prisma/data
+    healthcheck:
+      test: curl --fail http://localhost:5173/resources/warm-cache || exit 1
+      interval: 40s
+      timeout: 30s
+      retries: 3
+      start_period: 60s
 
 volumes:
   sqlite-data:

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "rom-manager",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@conform-to/react": "^1.2.2",
         "@conform-to/zod": "^1.2.2",
@@ -37,6 +37,7 @@
         "embla-carousel-react": "^8.3.0",
         "intl-parse-accept-language": "^1.0.0",
         "isbot": "^4.1.0",
+        "localforage": "^1.10.0",
         "lru-cache": "^11.0.1",
         "lucide-react": "^0.447.0",
         "prisma": "^5.21.1",
@@ -2599,9 +2600,9 @@
       "license": "MIT"
     },
     "node_modules/@remix-run/dev": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-2.12.1.tgz",
-      "integrity": "sha512-XjvpQZDvPL5L2NPUL9suwn0eo/WCHSewivpEEm2G1Ke06xL7LenIc8HzwkgsJqDrfvxePAFPj+RCcrygQvtMzA==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-2.13.1.tgz",
+      "integrity": "sha512-7+06Dail6zMyRlRvgrZ4cmQjs2gUb+M24iP4jbmql+0B7VAAPwzCRU0x+BF5z8GSef13kDrH3iXv/BQ2O2yOgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2615,9 +2616,9 @@
         "@babel/types": "^7.22.5",
         "@mdx-js/mdx": "^2.3.0",
         "@npmcli/package-json": "^4.0.1",
-        "@remix-run/node": "2.12.1",
-        "@remix-run/router": "1.19.2",
-        "@remix-run/server-runtime": "2.12.1",
+        "@remix-run/node": "2.13.1",
+        "@remix-run/router": "1.20.0",
+        "@remix-run/server-runtime": "2.13.1",
         "@types/mdx": "^2.0.5",
         "@vanilla-extract/integration": "^6.2.0",
         "arg": "^5.0.1",
@@ -2631,7 +2632,7 @@
         "esbuild-plugins-node-modules-polyfill": "^1.6.0",
         "execa": "5.1.1",
         "exit-hook": "2.2.1",
-        "express": "^4.19.2",
+        "express": "^4.20.0",
         "fs-extra": "^10.0.0",
         "get-port": "^5.1.1",
         "gunzip-maybe": "^1.4.2",
@@ -2657,7 +2658,7 @@
         "set-cookie-parser": "^2.6.0",
         "tar-fs": "^2.1.1",
         "tsconfig-paths": "^4.0.0",
-        "ws": "^7.4.5"
+        "ws": "^7.5.10"
       },
       "bin": {
         "remix": "dist/cli.js"
@@ -2666,8 +2667,8 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@remix-run/react": "^2.12.1",
-        "@remix-run/serve": "^2.12.1",
+        "@remix-run/react": "^2.13.1",
+        "@remix-run/serve": "^2.13.1",
         "typescript": "^5.1.0",
         "vite": "^5.1.0",
         "wrangler": "^3.28.2"
@@ -3100,18 +3101,18 @@
       }
     },
     "node_modules/@remix-run/express": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-2.12.1.tgz",
-      "integrity": "sha512-CW5coZXxk8251Tr0Fh9jmhda5Xt/BWfnUyD7jxth30irpWAEQcsaBu4pSDKuRvnJ8j2o7087EBnUn7oCB4ofNg==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-2.13.1.tgz",
+      "integrity": "sha512-yl3/BSJ8eyvwUyWCLDq3NlS81mZFll9hnADNuSCCBrQgkMhEx7stk5JUmWdvmcmGqHw04Ahkq07ZqJeD4F1FMA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/node": "2.12.1"
+        "@remix-run/node": "2.13.1"
       },
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "express": "^4.19.2",
+        "express": "^4.20.0",
         "typescript": "^5.1.0"
       },
       "peerDependenciesMeta": {
@@ -3121,12 +3122,12 @@
       }
     },
     "node_modules/@remix-run/node": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.12.1.tgz",
-      "integrity": "sha512-d+IHvEEU3qziporgpEyKFvKdmNaDu+a/9pIxBkNKVWdKx2JR0VRFIaUxxpxISWtkJcoNuERhW2xYa6YvtFp4ig==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.13.1.tgz",
+      "integrity": "sha512-2ly7bENj2n2FNBdEN60ZEbNCs5dAOex/QJoo6EZ8RNFfUQxVKAZkMwfQ4ETV2SLWDgkRLj3Jo5n/dx7O2ZGhGw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/server-runtime": "2.12.1",
+        "@remix-run/server-runtime": "2.13.1",
         "@remix-run/web-fetch": "^4.4.2",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie-signature": "^1.1.0",
@@ -3147,15 +3148,15 @@
       }
     },
     "node_modules/@remix-run/react": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.12.1.tgz",
-      "integrity": "sha512-+AFR6oCcAndlUZvr42dNrY2zprhf5Yo5Wl7TBocO3YPmwLkdrzJz+e8Sezk25qgHBB9cCTigt+yyliXmsZ1mpg==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.13.1.tgz",
+      "integrity": "sha512-kZevCoKMz0ZDOOzTnG95yfM7M9ju38FkWNY1wtxCy+NnUJYrmTerGQtiBsJgMzYD6i29+w4EwoQsdqys7DmMSg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.19.2",
-        "@remix-run/server-runtime": "2.12.1",
-        "react-router": "6.26.2",
-        "react-router-dom": "6.26.2",
+        "@remix-run/router": "1.20.0",
+        "@remix-run/server-runtime": "2.13.1",
+        "react-router": "6.27.0",
+        "react-router-dom": "6.27.0",
         "turbo-stream": "2.4.0"
       },
       "engines": {
@@ -3173,25 +3174,25 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.2.tgz",
-      "integrity": "sha512-baiMx18+IMuD1yyvOGaHM9QrVUPGGG0jC+z+IPHnRJWUAUvaKuWKyE8gjDj2rzv3sz9zOGoRSPgeBVHRhZnBlA==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.20.0.tgz",
+      "integrity": "sha512-mUnk8rPJBI9loFDZ+YzPGdeniYK+FTmRD1TMCz7ev2SNIozyKKpnGgsxO34u6Z4z/t0ITuu7voi/AshfsGsgFg==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@remix-run/serve": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/serve/-/serve-2.12.1.tgz",
-      "integrity": "sha512-J9BL5t2Alz45G/17vjD7YRuiRM+V4rJi63Kj+bmewuKWNXDEyij2LqgZJpkoHpkNsQFGiaBMNGc8bPd8RRmrxA==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/serve/-/serve-2.13.1.tgz",
+      "integrity": "sha512-lKCU1ZnHaGknRAYII5PQOGch9xzK3Q68mcyN8clN6WoKQTn5fvWVE1nEDd1L7vyt5LPVI2b7HNQtVMow1g1vHg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/express": "2.12.1",
-        "@remix-run/node": "2.12.1",
+        "@remix-run/express": "2.13.1",
+        "@remix-run/node": "2.13.1",
         "chokidar": "^3.5.3",
         "compression": "^1.7.4",
-        "express": "^4.19.2",
+        "express": "^4.20.0",
         "get-port": "5.1.1",
         "morgan": "^1.10.0",
         "source-map-support": "^0.5.21"
@@ -3204,12 +3205,12 @@
       }
     },
     "node_modules/@remix-run/server-runtime": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.12.1.tgz",
-      "integrity": "sha512-iuj9ju34f0LztPpd5dVuTXgt4x/MJeRsBiLuEx02nDSMGoNCAIx2LdeNYvE+XXdsf1Ht2NMlpRU+HBPCz3QLZg==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.13.1.tgz",
+      "integrity": "sha512-2DfBPRcHKVzE4bCNsNkKB50BhCCKF73x+jiS836OyxSIAL+x0tguV2AEjmGXefEXc5AGGzoxkus0AUUEYa29Vg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.19.2",
+        "@remix-run/router": "1.20.0",
         "@types/cookie": "^0.6.0",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie": "^0.6.0",
@@ -7087,9 +7088,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
-      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
+      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
@@ -7097,7 +7098,7 @@
         "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -7126,6 +7127,15 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/express/node_modules/cookie-signature": {
@@ -7978,6 +7988,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -8872,6 +8888,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.2.tgz",
@@ -8915,6 +8940,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lie": "3.1.1"
       }
     },
     "node_modules/locate-path": {
@@ -11565,12 +11599,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.26.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.2.tgz",
-      "integrity": "sha512-tvN1iuT03kHgOFnLPfLJ8V95eijteveqdOSk+srqfePtQvqCExB8eHOYnlilbOcyJyKnYkr1vJvf7YqotAJu1A==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.27.0.tgz",
+      "integrity": "sha512-YA+HGZXz4jaAkVoYBE98VQl+nVzI+cVI2Oj/06F5ZM+0u3TgedN9Y9kmMRo2mnkSK2nCpNQn0DVob4HCsY/WLw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.19.2"
+        "@remix-run/router": "1.20.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -11580,13 +11614,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.26.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.26.2.tgz",
-      "integrity": "sha512-z7YkaEW0Dy35T3/QKPYB1LjMK2R1fxnHO8kWpUMTBdfVzZrWOiY9a7CtN8HqdWtDUWd5FY6Dl8HFsqVwH4uOtQ==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.27.0.tgz",
+      "integrity": "sha512-+bvtFWMC0DgAFrfKXKG9Fc+BcXWRUO1aJIihbB79xaeq0v5UzfvnM5houGUm1Y461WVRcgAQ+Clh5rdb1eCx4g==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.19.2",
-        "react-router": "6.26.2"
+        "@remix-run/router": "1.20.0",
+        "react-router": "6.27.0"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "embla-carousel-react": "^8.3.0",
     "intl-parse-accept-language": "^1.0.0",
     "isbot": "^4.1.0",
+    "localforage": "^1.10.0",
     "lru-cache": "^11.0.1",
     "lucide-react": "^0.447.0",
     "prisma": "^5.21.1",


### PR DESCRIPTION
- Move cache logic from cache.server.ts to dedicated cache/ directory
- Add client-side caching using localforage for improved performance
- Introduce client loader for explore route to handle cache invalidation
- Simplify cache key generation by removing user-specific keys
- Update cache busting to work with new architecture
- Add health check in docker-compose for cache warming

This refactor improves application performance by reducing server load and providing faster data access through client-side caching.

NOTE: Leaving pre-warming (lol) until I can find a good resource on triggering it after build